### PR TITLE
Add device: OnePlus One

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -182,6 +182,15 @@
       "firefoxOS": false
     },
     {
+      "name": "OnePlus One",
+      "width": 360,
+      "height": 640,
+      "pixelRatio": 3,
+      "userAgent": "Mozilla/5.0 (Android 5.1.1; Mobile; rv:43.0) Gecko/43.0 Firefox/43.0",
+      "touch": true,
+      "firefoxOS": false
+    },
+    {
       "name": "Samsung Galaxy S III",
       "width": 360,
       "height": 640,


### PR DESCRIPTION
Hi :)

I'm adding the [**OnePlus One**](https://fr.wikipedia.org/wiki/OnePlus_One) phone device.
I haven't tested already the [**OnePlus Two**](https://fr.wikipedia.org/wiki/OnePlus_2) but it has the same screen dimension.

Notice, I'm not sure about what corresponds the `firefoxOS` attribute.
