### PR TITLE
update link to mozilla/simulated-devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div class="container">
-    <form id=form method="get" action="https://github.com/jankeromnes/devices/issues/new">
+    <form id=form method="get" action="https://github.com/mozilla/simulated-devices/issues/new">
       <div class="form-group">
         <label for="title">Device Name</label>
         <input type="text" name=title id=title


### PR DESCRIPTION
This makes the device page work again: http://mozilla.github.io/simulated-devices/
