### PR TITLE
Tag 1.0.0 and publish as an NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "devices.json",
+  "version": "1.0.0",
+  "description": "A catalog of common web-enabled devices.",
+  "main": "devices.json",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mozilla/simulated-devices"
+  },
+  "author": "Mozilla",
+  "license": "CC0-1.0",
+  "bugs": {
+    "url": "https://github.com/mozilla/simulated-devices/issues"
+  },
+  "homepage": "https://code.cdn.mozilla.net/devices/devices.json"
+}


### PR DESCRIPTION
This allows getting the catalog like so:

```
$ npm install devices.json
$ node
> require('devices.json')
```

Ideally, we should also automate the S3 and NPM deployments of this catalog, e.g. on every Git tag with Travis CI [like so](https://docs.travis-ci.com/user/deployment/#deploying-to-multiple-providers).