### PR TITLE
[WIP] Auto-deploy to NPM and S3 using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,22 @@
 language: node_js
 node_js: 10
 deploy:
-  provider: npm
-  email:
-    secure: FMpWsOFqHY3KN3foFcJOtK2C4BNy4AJjnd35l/RKANSvBm3Vhv+vhCO8rrcqKqTs83+JQg/Y961HOJLnfjqMyw6F/j36Ndc5+1tShWmdCby7QGUt1aKxJcxNDKwr8T5tv209OqIIepEsIZJLnCx3RCEDhviIye2Vd/DKd873MSA=
-  api_key:
-    secure: E6KUvWjEjGfzy+/kQNhKVUW+euhdmB8f1FCt2xbwFJxbfxb7UtTtVeLX48O+yUDfdLjHvc3Q/tgysuOBG+z/5HrSAuOk+01CI5mB6jNs0HrZphKqV4koxvaNbjkgv74uma8xirat/GePsxXTV1GyQHkLRTtzPV9O8lHIvoZgT3k=
-  on:
-    branch: master
-    tags: true
+  - provider: npm
+    email:
+      secure: FMpWsOFqHY3KN3foFcJOtK2C4BNy4AJjnd35l/RKANSvBm3Vhv+vhCO8rrcqKqTs83+JQg/Y961HOJLnfjqMyw6F/j36Ndc5+1tShWmdCby7QGUt1aKxJcxNDKwr8T5tv209OqIIepEsIZJLnCx3RCEDhviIye2Vd/DKd873MSA=
+    api_key:
+      secure: E6KUvWjEjGfzy+/kQNhKVUW+euhdmB8f1FCt2xbwFJxbfxb7UtTtVeLX48O+yUDfdLjHvc3Q/tgysuOBG+z/5HrSAuOk+01CI5mB6jNs0HrZphKqV4koxvaNbjkgv74uma8xirat/GePsxXTV1GyQHkLRTtzPV9O8lHIvoZgT3k=
+    on:
+      branch: master
+      tags: true
+  - provider: s3
+    access_key_id:
+      secure: TODO
+    secret_access_key:
+      secure: TODO
+    bucket: "TODO"
+    acl: public-read
+    cache_control: "max-age=86400"
+    on:
+      branch: master
+      tags: true


### PR DESCRIPTION
This is a follow-up to #30. As discussed in https://github.com/mozilla/simulated-devices/pull/30#issuecomment-438724907, we'd like to automate the deployments to NPM and S3.

This commit is a work-in-progress Travis CI configuration to achieve this.

## ~~TODO for NPM~~:

- [x] ~~use `travis encrypt` to encrypt NPM's `email` and `api_key` fields (after getting a token from https://npmjs.com, simply replace all `secure: TODO` by `secure: theoutputoftravisencrypt`)~~ (split out into #32)

## TODO for S3:

- [ ] same for S3's `access_key_id` and `secret_access_key` credentials (might have to ask security first though)
- [ ] figure out how to configure the other S3 options/commands in `deploy.sh`:
  - [ ] `--profile code.cdn.mozilla.net`
  - [ ] `s3 cp`
  - [x] `--acl public-read`
  - [x] `--cache-control max-age=86400`
  - [ ] `--content-type application/json`
  - [ ] `devices.json`
  - [ ] `s3://code-origin-cdn-mozilla-net/devices/devices.json`