### PR TITLE
Ipad Pro 12.9 inch height should be 1366px not 1336px (2732px/2)

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -248,7 +248,7 @@
     {
       "name": "iPad Pro (12.9-inch)",
       "width": 1024,
-      "height": 1336,
+      "height": 1366,
       "pixelRatio": 2,
       "userAgent": "Mozilla/5.0 (iPad; CPU OS 11_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1",
       "touch": true,


### PR DESCRIPTION
I think the height for the iPad Pro 12.9 inch tablet is a typo. The specs say it is 2732px/2 = 1366px not 1336px.

https://support.apple.com/kb/sp723?locale=en_US